### PR TITLE
Attempt to do setup-haskell steps manually

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,6 +9,8 @@ jobs:
       steps:
         - name: Install Stack
           run: |
+            which stack
+            stack --version
             mkdir -p ~/.local/bin
             curl -sSL https://github.com/commercialhaskell/stack/releases/download/v2.7.3/stack-2.7.3-linux-x86_64.tar.gz \
                 | tar -x -z -C ~/.local/bin --strip-components=1 --wildcards '*stack'
@@ -34,5 +36,3 @@ jobs:
         - name: Run tests
           run: |
             stack test
-            echo "PATH=$PATH"
-            ls ~/.local/bin

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -33,4 +33,5 @@ jobs:
         - name: Run tests
           run: |
             stack test
-            ls /usr/local/bin
+            echo "PATH=$PATH"
+            ls ~/.local/bin

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,14 +7,6 @@ jobs:
       name: Build and Test
       runs-on: ubuntu-latest
       steps:
-        - name: Install Stack
-          run: |
-            which stack
-            stack --version
-            mkdir -p ~/.local/bin
-            curl -sSL https://github.com/commercialhaskell/stack/releases/download/v2.7.3/stack-2.7.3-linux-x86_64.tar.gz \
-                | tar -x -z -C ~/.local/bin --strip-components=1 --wildcards '*stack'
-
         - name: Clone project
           uses: actions/checkout@v2
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -33,3 +33,4 @@ jobs:
         - name: Run tests
           run: |
             stack test
+            ls /usr/local/bin

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,8 +9,9 @@ jobs:
       steps:
         - name: Install Stack
           run: |
+            mkdir -p ~/.local/bin
             curl -sSL https://github.com/commercialhaskell/stack/releases/download/v2.7.3/stack-2.7.3-linux-x86_64.tar.gz \
-            | tar -x -z -C ~/.local/bin --strip-components=1 --wildcards '*stack'
+                | tar -x -z -C ~/.local/bin --strip-components=1 --wildcards '*stack'
 
         - name: Clone project
           uses: actions/checkout@v2

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,7 +10,7 @@ jobs:
         - name: Install Stack
           run: |
             curl -sSL https://github.com/commercialhaskell/stack/releases/download/v2.7.3/stack-2.7.3-linux-x86_64.tar.gz \
-            | tar -x -z -C /usr/local/bin --strip-components=1 --wildcards '*stack'
+            | tar -x -z -C ~/.local/bin --strip-components=1 --wildcards '*stack'
 
         - name: Clone project
           uses: actions/checkout@v2

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,14 +7,10 @@ jobs:
       name: Build and Test
       runs-on: ubuntu-latest
       steps:
-        - name: Setup GHC
-          uses: haskell/actions/setup@v1.2
-          with:
-            enable-stack: true
-            stack-no-global: true
-            stack-setup-ghc: true
-            ghc-version: '8.10.7'
-            stack-version: '2.7.3'
+        - name: Install Stack
+          run: |
+            curl -sSL https://github.com/commercialhaskell/stack/releases/download/v2.7.3/stack-2.7.3-linux-x86_64.tar.gz \
+            | tar -x -z -C /usr/local/bin --strip-components=1 --wildcards '*stack'
 
         - name: Clone project
           uses: actions/checkout@v2
@@ -26,8 +22,14 @@ jobs:
             key: ${{ runner.os }}-${{ hashFiles('stack.yaml') }}
             restore-keys: ${{ runner.os }}-
 
+        - name: Setup GHC
+          run: |
+            stack setup
+
         - name: Build sources
-          run: "stack build"
+          run: |
+            stack build
 
         - name: Run tests
-          run: "stack test"
+          run: |
+            stack test

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -16,7 +16,7 @@ jobs:
           uses: actions/checkout@v2
 
         - name: Cache dependencies
-          uses: actions/cache@v1
+          uses: actions/cache@v2
           with:
             path: ~/.stack
             key: ${{ runner.os }}-${{ hashFiles('stack.yaml') }}


### PR DESCRIPTION
The default `haskell/actions/setup` action seems to take a global snapshot rather than the one in the repo, interfering with caching. Experiment with doing what it does directly, like we've done in Docker based setups.